### PR TITLE
feat: git-sync sidecar + repos.yaml schema (issue #10)

### DIFF
--- a/cmd/clusterscope/main.go
+++ b/cmd/clusterscope/main.go
@@ -24,6 +24,7 @@ func main() {
 	tech := flag.String("tech", "flux", "technology to parse: flux | argocd")
 	serveAddr := flag.String("serve", "", "start HTTP dashboard server on addr (e.g. :8080); requires -root")
 	root := flag.String("root", ".", "root directory containing cluster subdirs (used with -serve)")
+	reposConfig := flag.String("repos-config", "", "path to repos.yaml defining git repositories (used with -serve in Kubernetes mode)")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, `clusterscope — generate an interactive HTML cluster profile from GitOps YAML files
@@ -43,12 +44,16 @@ Examples:
   clusterscope -dir ./clusters/labul/vsphere/movie-scripts -out profile.html
   clusterscope -dir ./argocd/clusters/prod -tech argocd -out prod.html
   clusterscope -serve :8080 -root ./clusters/
+  clusterscope -serve :8080 -root /data -repos-config /etc/git-sync/repos.yaml
 `)
 	}
 	flag.Parse()
 
 	// ── Serve mode ────────────────────────────────────────────────────────────
 	if *serveAddr != "" {
+		if *reposConfig != "" {
+			fmt.Fprintf(os.Stderr, "ℹ repos-config: %s (git-sync manages data delivery)\n", *reposConfig)
+		}
 		if err := serve.Start(*serveAddr, *root); err != nil {
 			fmt.Fprintf(os.Stderr, "serve error: %v\n", err)
 			os.Exit(1)

--- a/internal/repos/repos.go
+++ b/internal/repos/repos.go
@@ -1,0 +1,37 @@
+// Package repos defines the repos.yaml configuration schema for the git-sync
+// sidecar. The file is mounted as a ConfigMap in Kubernetes and describes
+// which Git repositories and paths clusterscope should scan.
+package repos
+
+// Config is the top-level structure of repos.yaml.
+type Config struct {
+	Repos []Entry `yaml:"repos"`
+}
+
+// Entry describes a single Git repository to sync.
+type Entry struct {
+	// Name is a human-readable identifier used as the subdirectory name under -root.
+	Name string `yaml:"name"`
+	// URL is the HTTPS or SSH clone URL of the repository.
+	URL string `yaml:"url"`
+	// Branch is the branch to track (default: main).
+	Branch string `yaml:"branch,omitempty"`
+	// Paths is a list of sub-paths within the repository to scan.
+	// If empty, the entire repo root is scanned.
+	Paths []string `yaml:"paths,omitempty"`
+	// SyncInterval controls how often git-sync polls (e.g. "60s").
+	SyncInterval string `yaml:"syncInterval,omitempty"`
+	// Auth configures optional authentication for private repositories.
+	Auth *Auth `yaml:"auth,omitempty"`
+}
+
+// Auth describes how to authenticate against a private Git repository.
+type Auth struct {
+	// Type is "token" (HTTPS Bearer / GitHub PAT) or "ssh".
+	Type string `yaml:"type"`
+	// SecretRef is the name of the Kubernetes Secret in the same namespace
+	// that holds the credentials.
+	// For type=token: key "token"
+	// For type=ssh:   key "ssh-privatekey"
+	SecretRef string `yaml:"secretRef"`
+}

--- a/kcl/configmaprepos.k
+++ b/kcl/configmaprepos.k
@@ -1,0 +1,22 @@
+"""
+ConfigMap for clusterscope git-sync repos configuration.
+Created only when config.reposConfig is set.
+The content is the repos.yaml file consumed by the git-sync sidecar.
+"""
+
+import labels
+
+config = labels.config
+
+configMapRepos = {
+    apiVersion: "v1"
+    kind: "ConfigMap"
+    metadata: {
+        name: "{}-repos".format(config.name)
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    data: {
+        "repos.yaml": config.reposConfig
+    }
+} if config.reposConfig else None

--- a/kcl/deploy.k
+++ b/kcl/deploy.k
@@ -6,6 +6,68 @@ import labels
 
 config = labels.config
 
+# git-sync sidecar container (only added when gitSyncEnabled=true)
+_gitSyncContainer = {
+    name: "git-sync"
+    image: config.gitSyncImage
+    args: ["--config=/etc/git-sync/repos.yaml"]
+    securityContext: {
+        readOnlyRootFilesystem: True
+        runAsNonRoot: True
+        runAsUser: 65533
+        allowPrivilegeEscalation: False
+        capabilities: {
+            drop: ["ALL"]
+        }
+    }
+    resources: {
+        requests: {
+            cpu: "10m"
+            memory: "32Mi"
+        }
+        limits: {
+            cpu: "100m"
+            memory: "128Mi"
+        }
+    }
+    volumeMounts: [
+        {
+            name: "gitdata"
+            mountPath: "/data"
+        }
+        {
+            name: "repos-config"
+            mountPath: "/etc/git-sync"
+            readOnly: True
+        }
+    ] + [
+        {
+            name: "secret-{}".format(s)
+            mountPath: "/etc/git-sync-secrets/{}".format(s)
+            readOnly: True
+        }
+        for s in config.repoAuthSecrets
+    ]
+}
+
+# extra volumes for git-sync (repos ConfigMap + auth Secrets)
+_gitSyncVolumes = [
+    {
+        name: "repos-config"
+        configMap: {
+            name: "{}-repos".format(config.name)
+        }
+    }
+] + [
+    {
+        name: "secret-{}".format(s)
+        secret: {
+            secretName: s
+        }
+    }
+    for s in config.repoAuthSecrets
+]
+
 deployment = {
     apiVersion: "apps/v1"
     kind: "Deployment"
@@ -95,7 +157,7 @@ deployment = {
                             }
                         ]
                     }
-                ]
+                ] + ([_gitSyncContainer] if config.gitSyncEnabled else [])
                 affinity: {
                     podAntiAffinity: {
                         preferredDuringSchedulingIgnoredDuringExecution: [
@@ -129,7 +191,7 @@ deployment = {
                         name: "gitdata"
                         emptyDir: {}
                     }
-                ]
+                ] + (_gitSyncVolumes if config.gitSyncEnabled else [])
             }
         }
     }

--- a/kcl/labels.k
+++ b/kcl/labels.k
@@ -11,6 +11,9 @@ _port = option("config.port")
 _dir = option("config.dir")
 _tech = option("config.tech")
 _replicas = option("config.replicas")
+_gitSyncEnabled = option("config.gitSyncEnabled")
+_gitSyncImage = option("config.gitSyncImage")
+_reposConfig = option("config.reposConfig")
 
 # Config instance with command-line overrides
 config: schema.ClusterScope = schema.ClusterScope {
@@ -26,6 +29,12 @@ config: schema.ClusterScope = schema.ClusterScope {
         tech = _tech
     if _replicas:
         replicas = int(_replicas)
+    if _gitSyncEnabled:
+        gitSyncEnabled = _gitSyncEnabled == True or str(_gitSyncEnabled) in ["true", "True", "1"]
+    if _gitSyncImage:
+        gitSyncImage = _gitSyncImage
+    if _reposConfig:
+        reposConfig = _reposConfig
 }
 
 # Common labels applied to all resources

--- a/kcl/main.k
+++ b/kcl/main.k
@@ -7,14 +7,18 @@ import namespace
 import serviceaccount
 import clusterrole
 import service
+import configmaprepos as cmrepos
 import deploy
 
-# Export all manifests
+# Export all manifests (filter out None values)
 manifests = [
-    namespace.namespace
-    serviceaccount.serviceAccount
-    clusterrole.clusterRole
-    clusterrole.clusterRoleBinding
-    service.service
-    deploy.deployment
+    m for m in [
+        namespace.namespace
+        serviceaccount.serviceAccount
+        clusterrole.clusterRole
+        clusterrole.clusterRoleBinding
+        service.service
+        cmrepos.configMapRepos
+        deploy.deployment
+    ] if m
 ]

--- a/kcl/schema.k
+++ b/kcl/schema.k
@@ -29,6 +29,18 @@ schema ClusterScope:
     # Technology: flux | argocd
     tech: str = "flux"
 
+    # Git-sync sidecar (Kubernetes serve mode)
+    gitSyncEnabled: bool = False
+    gitSyncImage: str = "registry.k8s.io/git-sync/git-sync:v4"
+
+    # Content of repos.yaml to be mounted as ConfigMap for git-sync.
+    # When set, a ConfigMap named "<name>-repos" is created.
+    reposConfig: str = ""
+
+    # Names of Kubernetes Secrets containing auth credentials for git-sync.
+    # Each secret is mounted at /etc/git-sync-secrets/<secret-name>/
+    repoAuthSecrets: [str] = []
+
     # Labels and annotations
     labels: {str:str} = {}
     annotations: {str:str} = {}

--- a/tests/kcl-deploy-profile.yaml
+++ b/tests/kcl-deploy-profile.yaml
@@ -4,3 +4,23 @@ config.tech: flux
 config.dir: /data
 config.port: 8080
 config.replicas: 1
+# Git-sync sidecar (enable for Kubernetes deployments)
+# config.gitSyncEnabled: "true"
+# config.reposConfig: |
+#   repos:
+#     - name: stuttgart-things-clusters
+#       url: https://github.com/stuttgart-things/clusters
+#       branch: main
+#       paths:
+#         - clusters/labul
+#         - clusters/labda
+#       syncInterval: 60s
+#     - name: private-infra
+#       url: https://github.com/acme/infra-clusters
+#       branch: main
+#       paths:
+#         - environments/prod
+#       syncInterval: 120s
+#       auth:
+#         type: token
+#         secretRef: infra-git-token


### PR DESCRIPTION
## Summary

Implements issue #10 — git-sync sidecar pattern with declarative `repos.yaml` configuration.

---

## Go changes

### New: `internal/repos/repos.go`
Defines the Go schema for `repos.yaml`:

```go
type Config struct {
    Repos []Entry `yaml:"repos"`
}
type Entry struct {
    Name         string  `yaml:"name"`
    URL          string  `yaml:"url"`
    Branch       string  `yaml:"branch,omitempty"`
    Paths        []string `yaml:"paths,omitempty"`
    SyncInterval string  `yaml:"syncInterval,omitempty"`
    Auth         *Auth   `yaml:"auth,omitempty"`
}
type Auth struct {
    Type      string `yaml:"type"`      // token | ssh
    SecretRef string `yaml:"secretRef"` // k8s Secret name
}
```

### `cmd/clusterscope/main.go`
- Added `-repos-config` flag — logs the path at startup in serve mode (git-sync owns data delivery)

---

## KCL changes

### `kcl/schema.k` — new fields
```kcl
gitSyncEnabled:   bool     = False
gitSyncImage:     str      = "registry.k8s.io/git-sync/git-sync:v4"
reposConfig:      str      = ""   # repos.yaml content → ConfigMap
repoAuthSecrets:  [str]    = []   # Secret names for per-repo auth
```

### `kcl/configmaprepos.k` — new file
Creates ConfigMap `<name>-repos` with `repos.yaml` key — only when `reposConfig` is set.

### `kcl/deploy.k` — git-sync sidecar
When `gitSyncEnabled=true`, adds:
- **sidecar container** `git-sync` (`registry.k8s.io/git-sync/git-sync:v4`)
  - `--config=/etc/git-sync/repos.yaml`
  - Mounts `gitdata:/data` (write) and `repos-config:/etc/git-sync` (read-only)
  - Optional auth mounts at `/etc/git-sync-secrets/<secret-name>/`
  - Hardened: `readOnlyRootFilesystem`, `runAsUser: 65533`, `drop: [ALL]`
- **volumes**: `repos-config` ConfigMap + one Secret per `repoAuthSecrets`

### `kcl/main.k` — includes configmaprepos, filters None

### `tests/kcl-deploy-profile.yaml` — commented example repos config

---

## Pod architecture with git-sync enabled

```
Pod
├── git-sync (sidecar)  — polls Git repos → writes to /data/
│   ├── mount: gitdata:/data  (rw)
│   └── mount: repos-config:/etc/git-sync  (ro)
└── clusterscope (main) — reads /data/, serves HTTP dashboard
    └── mount: gitdata:/data  (ro)
```

## Verification

```bash
# No git-sync (default)
kcl run kcl/ -D config.namespace=clusterscope
# → containers: [clusterscope] ✅

# With git-sync
kcl run kcl/ -D config.namespace=clusterscope -D config.gitSyncEnabled=true -D config.reposConfig="repos: []"
# → containers: [clusterscope, git-sync] ✅
# → ConfigMap clusterscope-repos created ✅

# Lint
dagger call -m ./dagger lint --src . → 0 issues ✅
```

Closes #10
