### PR TITLE
feat: multi-cluster static dashboard + UI redesign

### DIFF
--- a/cmd/clusterscope/main.go
+++ b/cmd/clusterscope/main.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 
 	"github.com/stuttgart-things/clusterscope/internal/render"
+	"github.com/stuttgart-things/clusterscope/internal/scan"
 	"github.com/stuttgart-things/clusterscope/internal/serve"
 	"github.com/stuttgart-things/clusterscope/pkg/argocd"
 	"github.com/stuttgart-things/clusterscope/pkg/flux"
@@ -62,8 +63,63 @@ Examples:
 	}
 
 	// ── Static render mode ────────────────────────────────────────────────────
-	var profile interface { /* graph.ClusterProfile */
+
+	// Multi-cluster mode: -root given without -serve
+	if *root != "." && *dir == "." {
+		outDir := *out
+		if outDir == "" {
+			outDir = "."
+		}
+		if err := os.MkdirAll(outDir, 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "error creating output dir: %v\n", err)
+			os.Exit(1)
+		}
+		clusters, err := scan.Root(*root)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error scanning root: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Write per-cluster HTML files
+		for _, c := range clusters {
+			if c.Err != nil || c.Profile == nil {
+				fmt.Fprintf(os.Stderr, "skip %s: %v\n", c.Name, c.Err)
+				continue
+			}
+			clusterFile := filepath.Join(outDir, c.Name+".html")
+			f, err := os.Create(clusterFile)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error creating %s: %v\n", clusterFile, err)
+				continue
+			}
+			if err := render.WriteHTML(f, c.Profile); err != nil {
+				fmt.Fprintf(os.Stderr, "error rendering %s: %v\n", c.Name, err)
+			}
+			_ = f.Close()
+			fmt.Fprintf(os.Stderr, "✓ %s → %s\n", c.Name, clusterFile)
+		}
+
+		// Write index.html
+		indexFile := filepath.Join(outDir, "index.html")
+		idxClusters := make([]render.IndexCluster, len(clusters))
+		for i, c := range clusters {
+			idxClusters[i] = render.IndexCluster{Name: c.Name, Profile: c.Profile, Err: c.Err}
+		}
+		fi, err := os.Create(indexFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error creating index.html: %v\n", err)
+			os.Exit(1)
+		}
+		if err := render.WriteIndex(fi, idxClusters); err != nil {
+			fmt.Fprintf(os.Stderr, "error rendering index: %v\n", err)
+		}
+		_ = fi.Close()
+		fmt.Fprintf(os.Stderr, "✓ index.html → %s\n", indexFile)
+		return
 	}
+
+	// Single-cluster mode
+	var profile interface{} //nolint:unused
 	_ = profile
 
 	switch *tech {

--- a/internal/render/index.html
+++ b/internal/render/index.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>clusterscope — cluster dashboard</title>
+<style>
+  *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+  body{font-family:'Segoe UI',Arial,sans-serif;background:#0d1117;color:#e6edf3;min-height:100vh}
+  .dashboard{max-width:1400px;margin:0 auto;padding:32px 24px;display:flex;flex-direction:column;gap:28px}
+
+  /* HEADER */
+  .header{padding:24px 28px;background:linear-gradient(135deg,#161b22 0%,#1c2431 100%);
+    border:1px solid #30363d;border-radius:12px;border-left:4px solid #7c83ff;
+    display:flex;align-items:center;gap:16px}
+  .header h1{font-size:26px;font-weight:700;color:#7c83ff}
+  .header .subtitle{font-size:13px;color:#8b949e;margin-top:4px}
+  .header .stats{margin-left:auto;display:flex;gap:20px;text-align:right}
+  .header .stat-val{font-size:22px;font-weight:700;color:#e6edf3}
+  .header .stat-lbl{font-size:11px;color:#8b949e;text-transform:uppercase;letter-spacing:.05em}
+
+  /* GRID */
+  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:16px}
+
+  /* CARD */
+  .card{background:#161b22;border:1px solid #30363d;border-radius:10px;padding:20px 22px;
+    display:flex;flex-direction:column;gap:12px;transition:border-color .2s,transform .15s;
+    text-decoration:none;color:inherit}
+  .card:hover{border-color:#58a6ff;transform:translateY(-2px)}
+  .card.argocd:hover{border-color:#34d399}
+  .card-header{display:flex;align-items:flex-start;justify-content:space-between;gap:8px}
+  .card-name{font-size:15px;font-weight:700;color:#e6edf3;word-break:break-all}
+  .badge{display:inline-flex;align-items:center;gap:5px;padding:3px 10px;border-radius:20px;
+    font-size:11px;font-weight:600;white-space:nowrap;flex-shrink:0}
+  .badge.flux{background:#1a2a40;color:#58a6ff;border:1px solid #1e3a60}
+  .badge.argocd{background:#162a22;color:#34d399;border:1px solid #1a3d2c}
+  .badge.mixed{background:#2a1e36;color:#d2a8ff;border:1px solid #3d2857}
+  .card-path{font-size:11px;color:#444c56;margin-top:-4px;word-break:break-all}
+  .card-stats{display:flex;gap:16px;flex-wrap:wrap}
+  .stat{display:flex;flex-direction:column;gap:2px}
+  .stat-n{font-size:20px;font-weight:700;color:#e6edf3}
+  .stat-l{font-size:10px;color:#8b949e;text-transform:uppercase;letter-spacing:.05em}
+  .card-meta{display:flex;gap:10px;flex-wrap:wrap;margin-top:4px}
+  .meta-chip{background:#21262d;border:1px solid #30363d;border-radius:6px;
+    padding:3px 8px;font-size:10px;color:#8b949e}
+  .meta-chip.sops{border-color:#d29922;color:#d29922}
+  .card-btn{margin-top:auto;background:#21262d;border:1px solid #30363d;border-radius:7px;
+    padding:8px 14px;font-size:12px;color:#58a6ff;text-align:center;font-weight:600;
+    transition:background .15s,border-color .15s}
+  .card:hover .card-btn{background:#1c2e46;border-color:#58a6ff}
+  .card.argocd .card-btn{color:#34d399}
+  .card.argocd:hover .card-btn{background:#162a22;border-color:#34d399}
+  .card.error{border-color:#f85149;opacity:.7}
+  .card.error .card-name{color:#f85149}
+  .error-msg{font-size:11px;color:#f85149;word-break:break-all}
+
+  /* FOOTER */
+  footer{text-align:center;font-size:11px;color:#444c56;padding:8px}
+</style>
+</head>
+<body>
+<div class="dashboard">
+  <div class="header">
+    <div>
+      <h1>⎈ clusterscope</h1>
+      <div class="subtitle">Multi-cluster GitOps dashboard</div>
+    </div>
+    <div class="stats">
+      <div>
+        <div class="stat-val">{{len .Clusters}}</div>
+        <div class="stat-lbl">Clusters</div>
+      </div>
+      <div>
+        <div class="stat-val">{{.TotalNodes}}</div>
+        <div class="stat-lbl">Total nodes</div>
+      </div>
+      <div>
+        <div class="stat-val">{{.TechSummary}}</div>
+        <div class="stat-lbl">Technologies</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="grid">
+    {{range .Clusters}}
+    {{if .Err}}
+    <div class="card error">
+      <div class="card-header">
+        <div class="card-name">{{.Name}}</div>
+        <span class="badge flux">error</span>
+      </div>
+      <div class="error-msg">{{.Err}}</div>
+    </div>
+    {{else}}
+    <a class="card {{.Profile.Technology}}" href="{{.Name}}.html">
+      <div class="card-header">
+        <div class="card-name">{{.Name}}</div>
+        {{if eq .Profile.Technology "argocd"}}<span class="badge argocd">🐙 ArgoCD</span>
+        {{else if eq .Profile.Technology "mixed"}}<span class="badge mixed">🔀 Mixed</span>
+        {{else}}<span class="badge flux">⚡ FluxCD</span>{{end}}
+      </div>
+      {{if .Profile.ClusterPath}}<div class="card-path">{{.Profile.ClusterPath}}</div>{{end}}
+      <div class="card-stats">
+        <div class="stat"><div class="stat-n">{{len .Profile.Graph.Nodes}}</div><div class="stat-l">Nodes</div></div>
+        <div class="stat"><div class="stat-n">{{len .Profile.Graph.Edges}}</div><div class="stat-l">Edges</div></div>
+        {{if .Profile.Meta}}{{with index .Profile.Meta "fluxVersion"}}<div class="stat"><div class="stat-n" style="font-size:13px">{{.}}</div><div class="stat-l">Flux version</div></div>{{end}}{{end}}
+      </div>
+      <div class="card-meta">
+        {{if .Profile.Meta}}
+          {{with index .Profile.Meta "sops"}}{{if eq . "true"}}<span class="meta-chip sops">🔐 SOPS</span>{{end}}{{end}}
+        {{end}}
+        {{range .Profile.Graph.Nodes}}{{if eq .Type "source"}}<span class="meta-chip">{{.ID}}</span>{{end}}{{end}}
+      </div>
+      <div class="card-btn">Open full visualization →</div>
+    </a>
+    {{end}}
+    {{end}}
+  </div>
+</div>
+<footer>generated by clusterscope</footer>
+</body>
+</html>

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -19,6 +19,22 @@ var htmlTemplate string
 //go:embed shell.html
 var shellTemplate string
 
+//go:embed index.html
+var indexTemplate string
+
+// IndexCluster is one row in the multi-cluster index page.
+type IndexCluster struct {
+	Name    string
+	Profile *graph.ClusterProfile
+	Err     error
+}
+
+type indexData struct {
+	Clusters    []IndexCluster
+	TotalNodes  int
+	TechSummary string
+}
+
 type kustCard struct {
 	Name      string
 	Path      string
@@ -224,4 +240,33 @@ func parseSub(sub string) (branch, interval string) {
 func WriteShell(w io.Writer) error {
 	_, err := io.WriteString(w, shellTemplate)
 	return err
+}
+
+// WriteIndex renders a multi-cluster index page from a list of cluster entries.
+func WriteIndex(w io.Writer, clusters []IndexCluster) error {
+	total := 0
+	techs := map[string]bool{}
+	for _, c := range clusters {
+		if c.Profile != nil {
+			total += len(c.Profile.Graph.Nodes)
+			techs[c.Profile.Technology] = true
+		}
+	}
+	techNames := make([]string, 0, len(techs))
+	for t := range techs {
+		techNames = append(techNames, t)
+	}
+	sort.Strings(techNames)
+
+	data := indexData{
+		Clusters:    clusters,
+		TotalNodes:  total,
+		TechSummary: strings.Join(techNames, " + "),
+	}
+
+	tmpl, err := template.New("index").Parse(indexTemplate)
+	if err != nil {
+		return err
+	}
+	return tmpl.Execute(w, data)
 }

--- a/internal/render/template.html
+++ b/internal/render/template.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8"/>
-<title>{{.ClusterName}} · Flux Cluster Profile</title>
+<title>{{.ClusterName}} · clusterscope</title>
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <style>
   *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
@@ -23,6 +23,8 @@
   .header-right{display:flex;flex-direction:column;align-items:flex-end;gap:8px}
   .flux-badge{background:#21262d;border:1px solid #30363d;border-radius:20px;
     padding:6px 14px;font-size:12px;color:#a5d6ff;display:flex;align-items:center;gap:6px}
+  .flux-badge.argocd{border-color:#34d399;color:#34d399}
+  .flux-badge.mixed{border-color:#d2a8ff;color:#d2a8ff}
 
   /* FILTER BAR */
   .filter-bar{background:#161b22;border:1px solid #30363d;border-radius:12px;
@@ -193,7 +195,7 @@
   <!-- HEADER -->
   <div class="header">
     <div class="header-left">
-      <h1>{{.ClusterName}} <span>· Flux Cluster Profile</span></h1>
+      <h1>{{.ClusterName}} <span>· cluster profile</span></h1>
       <div class="subtitle">
         <span><span class="dot"></span> {{.ClusterPath}}</span>
         {{if .FluxInstance}}<span>⚡ FluxCD v{{.FluxInstance.Version}}</span>{{end}}
@@ -202,10 +204,19 @@
       </div>
     </div>
     <div class="header-right">
-      {{if .FluxInstance}}<div class="flux-badge">⚡ FluxCD v{{.FluxInstance.Version}}</div>{{end}}
-      {{if .FluxSops}}<div class="flux-badge">🔐 SOPS Age Decryption</div>{{end}}
-      <div class="flux-badge">📦 {{len .Kustomizations}} Kustomizations</div>
-      <div class="flux-badge">🌿 {{len .GitRepos}} Git Sources</div>
+      {{if eq .Technology "flux"}}
+        {{if .FluxInstance}}<div class="flux-badge">⚡ FluxCD v{{.FluxInstance.Version}}</div>{{end}}
+        {{if .FluxSops}}<div class="flux-badge">🔐 SOPS Age Decryption</div>{{end}}
+        <div class="flux-badge">📦 {{len .Kustomizations}} Kustomizations</div>
+        <div class="flux-badge">🌿 {{len .GitRepos}} Git Sources</div>
+      {{else if eq .Technology "argocd"}}
+        <div class="flux-badge argocd">🐙 ArgoCD</div>
+        {{if .HasArgoProjects}}<div class="flux-badge argocd">📁 {{len .ArgoProjects}} Projects</div>{{end}}
+        {{if .HasArgoAppSets}}<div class="flux-badge argocd">🔗 {{len .ArgoAppSets}} ApplicationSets</div>{{end}}
+        {{if .HasArgoApps}}<div class="flux-badge argocd">📦 {{len .ArgoApps}} Applications</div>{{end}}
+      {{else}}
+        <div class="flux-badge mixed">🔀 Mixed GitOps</div>
+      {{end}}
       <button class="print-btn" onclick="window.print()">🖨 Print / Save as PDF</button>
     </div>
   </div>
@@ -214,10 +225,13 @@
   <div class="filter-bar">
     <span class="filter-label">Layers</span>
     {{if .HasSources}}<button class="toggle-btn active" style="--c:#ffa657" onclick="toggleLayer('sources',this)"><span class="btn-dot"></span> Git Sources</button>{{end}}
-    {{if .HasControllers}}<button class="toggle-btn active" style="--c:#21d4a4" onclick="toggleLayer('controllers',this)"><span class="btn-dot"></span> Flux Controllers</button>{{end}}
+    {{if .HasControllers}}<button class="toggle-btn active" style="--c:#21d4a4" onclick="toggleLayer('controllers',this)"><span class="btn-dot"></span>{{if eq .Technology "argocd"}} ArgoCD Controllers{{else}} Flux Controllers{{end}}</button>{{end}}
     {{if .HasInfra}}<button class="toggle-btn active" style="--c:#f78166" onclick="toggleLayer('infra',this)"><span class="btn-dot"></span> Infrastructure</button>{{end}}
     {{if .HasApps}}<button class="toggle-btn active" style="--c:#3fb950" onclick="toggleLayer('apps',this)"><span class="btn-dot"></span> Applications</button>{{end}}
     {{if .HasHomerun}}<button class="toggle-btn active" style="--c:#d2a8ff" onclick="toggleLayer('homerun',this)"><span class="btn-dot"></span> Homerun2 Stack</button>{{end}}
+    {{if .HasArgoProjects}}<button class="toggle-btn active" style="--c:#60a5fa" onclick="toggleLayer('argoproject',this)"><span class="btn-dot"></span> Projects</button>{{end}}
+    {{if .HasArgoAppSets}}<button class="toggle-btn active" style="--c:#34d399" onclick="toggleLayer('argoappset',this)"><span class="btn-dot"></span> ApplicationSets</button>{{end}}
+    {{if .HasArgoApps}}<button class="toggle-btn active" style="--c:#a78bfa" onclick="toggleLayer('argoapp',this)"><span class="btn-dot"></span> Applications</button>{{end}}
     <div class="filter-sep"></div>
     <span class="filter-label">View</span>
     <button class="toggle-btn active" style="--c:#58a6ff" onclick="toggleLayer('graph',this)"><span class="btn-dot"></span> Dependency Graph</button>

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -1,0 +1,102 @@
+// Package scan discovers cluster directories and auto-detects their technology.
+package scan
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/stuttgart-things/clusterscope/internal/graph"
+	"github.com/stuttgart-things/clusterscope/pkg/argocd"
+	"github.com/stuttgart-things/clusterscope/pkg/flux"
+)
+
+// ClusterEntry holds a parsed cluster profile together with scan metadata.
+type ClusterEntry struct {
+	Name    string
+	Profile *graph.ClusterProfile
+	Err     error
+}
+
+// Root walks root, discovers all immediate subdirectories that contain YAML
+// files, auto-detects their technology, and returns one ClusterEntry per dir.
+func Root(root string) ([]ClusterEntry, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []ClusterEntry
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(root, e.Name())
+		if !hasYAML(dir) {
+			continue
+		}
+
+		tech := DetectTech(dir)
+		var profile *graph.ClusterProfile
+		var pErr error
+
+		switch tech {
+		case "argocd":
+			profile, pErr = argocd.ParseDir(dir)
+		default:
+			profile, pErr = flux.ParseDir(dir)
+		}
+
+		results = append(results, ClusterEntry{
+			Name:    e.Name(),
+			Profile: profile,
+			Err:     pErr,
+		})
+	}
+	return results, nil
+}
+
+// DetectTech returns "argocd" when any .yaml file in dir contains ArgoCD
+// markers, otherwise returns "flux".
+func DetectTech(dir string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "flux"
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		content := string(data)
+		if strings.Contains(content, "argoproj.io") ||
+			strings.Contains(content, "kind: Application") {
+			return "argocd"
+		}
+	}
+	return "flux"
+}
+
+// hasYAML returns true if dir contains at least one .yaml/.yml file.
+func hasYAML(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			n := e.Name()
+			if strings.HasSuffix(n, ".yaml") || strings.HasSuffix(n, ".yml") {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/stuttgart-things/clusterscope/internal/graph"
 	"github.com/stuttgart-things/clusterscope/internal/render"
+	"github.com/stuttgart-things/clusterscope/internal/scan"
 	"github.com/stuttgart-things/clusterscope/pkg/argocd"
 	"github.com/stuttgart-things/clusterscope/pkg/flux"
 )
@@ -78,7 +79,7 @@ func (s *Server) scanAll() {
 }
 
 func (s *Server) scanCluster(path, name string) {
-	tech := detectTech(path)
+	tech := scan.DetectTech(path)
 	var profile *graph.ClusterProfile
 	var err error
 
@@ -99,30 +100,6 @@ func (s *Server) scanCluster(path, name string) {
 	s.scanned[name] = time.Now()
 	s.mu.Unlock()
 	log.Printf("scanned %s  tech=%s  nodes=%d", name, tech, len(profile.Graph.Nodes))
-}
-
-// detectTech returns "argocd" if any .yaml in dir contains ArgoCD markers,
-// otherwise "flux".
-func detectTech(dir string) string {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return "flux"
-	}
-	for _, e := range entries {
-		if e.IsDir() || (!strings.HasSuffix(e.Name(), ".yaml") && !strings.HasSuffix(e.Name(), ".yml")) {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
-		if err != nil {
-			continue
-		}
-		content := string(data)
-		if strings.Contains(content, "argoproj.io") ||
-			strings.Contains(content, "kind: Application") {
-			return "argocd"
-		}
-	}
-	return "flux"
 }
 
 // ── file watcher ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements issue #1 (multi-cluster static mode) and issue #5 (technology-agnostic UI redesign).

---

## Issue #1 — Multi-cluster static dashboard

**New:** `internal/scan/scan.go`
- `Root(root string) ([]ClusterEntry, error)` — walks a root directory, parses each cluster's profile YAML
- `DetectTech(dir string) string` — returns `"argocd"` or `"flux"` based on YAML content inspection
- `hasYAML(dir string) bool` — helper to check for YAML files in a directory

**New:** `internal/render/index.html`
- Responsive cluster card grid dashboard template
- Each card: cluster name, technology badge, node/edge count, version, SOPS indicator, sources list
- Links through to `<cluster-name>.html`

**Modified:** `internal/render/render.go`
- `//go:embed index.html` → `var indexTemplate string`
- New types: `IndexCluster{Name, Profile, Err}`, `indexData{Clusters, TotalNodes, TechSummary}`
- New function: `WriteIndex(w io.Writer, clusters []IndexCluster) error`

**Modified:** `cmd/clusterscope/main.go`
- Multi-cluster static mode: when `-root <dir>` is given without `-serve`, generates `index.html` + per-cluster HTML files
- `os.MkdirAll(outDir, 0o755)` ensures output directory is created

**Modified:** `internal/serve/serve.go`
- Removed duplicate `detectTech()` function
- Added import: `github.com/stuttgart-things/clusterscope/internal/scan`
- Uses `scan.DetectTech(path)` instead of the local duplicate

**Usage:**
```bash
clusterscope -root ./clusters -out ./dist
# Generates: dist/index.html, dist/cluster-a.html, dist/cluster-b.html, ...
```

---

## Issue #5 — Technology-agnostic UI redesign

**Modified:** `internal/render/template.html`
- Title: `{{.ClusterName}} · cluster profile` (was hardcoded "Flux Cluster Profile")
- Technology badge in header is now conditional:
  - `flux`: ⚡ FluxCD + version, SOPS, kustomization count, git source count
  - `argocd`: 🐙 ArgoCD + project/appset/app counts
  - else: 🔀 Mixed GitOps
- Filter bar label dynamic: `Flux Controllers` vs `ArgoCD Controllers`
- ArgoCD-specific layer buttons: Projects, ApplicationSets, Applications (conditional on data presence)
- CSS additions: `.flux-badge.argocd` (green) and `.flux-badge.mixed` (yellow) variants

---

Closes #1
Closes #5