### PR TITLE
feat: live mode — real-time kubectl status enrichment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# Task remote cache
+.task/

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -98,6 +98,42 @@ tasks:
     cmds:
       - go run ./cmd/clusterscope -dir {{ .DIR }} -serve :{{ .PORT }}
 
+  ui-serve:
+    desc: Serve multi-cluster UI locally (live dashboard, auto-reload on changes)
+    vars:
+      ROOT: '{{ .ROOT | default "/tmp/test-clusters" }}'
+      PORT: '{{ .PORT | default "8080" }}'
+    cmds:
+      - echo "Starting clusterscope dashboard at http://localhost:{{ .PORT }} (root={{ .ROOT }})"
+      - go run ./cmd/clusterscope -serve :{{ .PORT }} -root {{ .ROOT }}
+
+  ui-serve-live:
+    desc: Serve multi-cluster UI with live kubectl status enrichment
+    vars:
+      ROOT: '{{ .ROOT | default "/tmp/test-clusters" }}'
+      PORT: '{{ .PORT | default "8080" }}'
+      KUBECONFIG: '{{ .KUBECONFIG | default "" }}'
+      REFRESH: '{{ .REFRESH | default "30" }}'
+    cmds:
+      - echo "Starting clusterscope LIVE dashboard at http://localhost:{{ .PORT }} (root={{ .ROOT }})"
+      - >
+        go run ./cmd/clusterscope
+        -serve :{{ .PORT }}
+        -root {{ .ROOT }}
+        -live
+        {{ if .KUBECONFIG }}-kubeconfig {{ .KUBECONFIG }}{{ end }}
+        -refresh {{ .REFRESH }}
+
+  ui-static:
+    desc: Generate static multi-cluster HTML dashboard locally
+    vars:
+      ROOT: '{{ .ROOT | default "/tmp/test-clusters" }}'
+      OUT: '{{ .OUT | default "/tmp/clusterscope-ui" }}'
+    cmds:
+      - go run ./cmd/clusterscope -root {{ .ROOT }} -out {{ .OUT }}
+      - echo "Dashboard generated at {{ .OUT }}/index.html"
+      - 'echo "Open with: xdg-open {{ .OUT }}/index.html"'
+
   trigger-release:
     desc: Trigger Release workflow on GitHub Actions
     cmds:

--- a/cmd/clusterscope/main.go
+++ b/cmd/clusterscope/main.go
@@ -26,6 +26,9 @@ func main() {
 	serveAddr := flag.String("serve", "", "start HTTP dashboard server on addr (e.g. :8080); requires -root")
 	root := flag.String("root", ".", "root directory containing cluster subdirs (used with -serve)")
 	reposConfig := flag.String("repos-config", "", "path to repos.yaml defining git repositories (used with -serve in Kubernetes mode)")
+	liveMode := flag.Bool("live", false, "enrich graph with real-time reconciliation status via kubectl")
+	kubeconfig := flag.String("kubeconfig", "", "path to kubeconfig file (default: KUBECONFIG env / ~/.kube/config)")
+	refreshSeconds := flag.Int("refresh", 30, "live status refresh interval in seconds (used with -live)")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, `clusterscope — generate an interactive HTML cluster profile from GitOps YAML files
@@ -46,6 +49,8 @@ Examples:
   clusterscope -dir ./argocd/clusters/prod -tech argocd -out prod.html
   clusterscope -serve :8080 -root ./clusters/
   clusterscope -serve :8080 -root /data -repos-config /etc/git-sync/repos.yaml
+  clusterscope -serve :8080 -root ./clusters/ -live -kubeconfig ~/.kube/prod
+  clusterscope -dir ./clusters/prod -tech flux -live -kubeconfig ~/.kube/prod -out live.html
 `)
 	}
 	flag.Parse()
@@ -55,7 +60,18 @@ Examples:
 		if *reposConfig != "" {
 			fmt.Fprintf(os.Stderr, "ℹ repos-config: %s (git-sync manages data delivery)\n", *reposConfig)
 		}
-		if err := serve.Start(*serveAddr, *root); err != nil {
+		if *liveMode && *kubeconfig != "" {
+			if _, err := os.Stat(*kubeconfig); err != nil {
+				fmt.Fprintf(os.Stderr, "kubeconfig not found: %s\n", *kubeconfig)
+				os.Exit(1)
+			}
+		}
+		opts := serve.Options{
+			Live:           *liveMode,
+			Kubeconfig:     *kubeconfig,
+			RefreshSeconds: *refreshSeconds,
+		}
+		if err := serve.Start(*serveAddr, *root, opts); err != nil {
 			fmt.Fprintf(os.Stderr, "serve error: %v\n", err)
 			os.Exit(1)
 		}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -17,6 +17,11 @@ type Node struct {
 	DependsOn  []string          `json:"dependsOn,omitempty"`
 	Substitute map[string]string `json:"substitute,omitempty"`
 	Technology string            `json:"technology"` // "flux" | "argocd"
+
+	// Live status — populated only when --live is active.
+	Status    string `json:"status,omitempty"`    // "ready" | "failed" | "progressing" | "unknown"
+	Message   string `json:"message,omitempty"`   // last condition message
+	UpdatedAt string `json:"updatedAt,omitempty"` // ISO-8601 timestamp
 }
 
 // Edge represents a directed dependency or watch relationship between nodes.

--- a/internal/live/live.go
+++ b/internal/live/live.go
@@ -1,0 +1,201 @@
+// Package live enriches a ClusterProfile graph with real-time reconciliation
+// status fetched from a running cluster via kubectl.
+//
+// No credentials are ever written to HTML output. KUBECONFIG follows standard
+// kubectl conventions: --kubeconfig flag > KUBECONFIG env > ~/.kube/config.
+package live
+
+import (
+	"encoding/json"
+	"os/exec"
+	"strings"
+
+	"github.com/stuttgart-things/clusterscope/internal/graph"
+)
+
+// NodeStatus carries the live reconciliation status for one resource.
+type NodeStatus struct {
+	Status    string // "ready" | "failed" | "progressing" | "unknown"
+	Message   string
+	UpdatedAt string
+}
+
+// ── internal k8s list shapes ─────────────────────────────────────────────────
+
+type k8sCondition struct {
+	Type               string `json:"type"`
+	Status             string `json:"status"`
+	Message            string `json:"message"`
+	LastTransitionTime string `json:"lastTransitionTime"`
+}
+
+type k8sItem struct {
+	Metadata struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"metadata"`
+	Status struct {
+		Conditions []k8sCondition `json:"conditions"`
+	} `json:"status"`
+}
+
+type k8sList struct {
+	Items []k8sItem `json:"items"`
+}
+
+// ArgoCD uses health/sync sub-objects instead of standard conditions.
+type argoItem struct {
+	Metadata struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"metadata"`
+	Status struct {
+		Health struct {
+			Status  string `json:"status"`
+			Message string `json:"message"`
+		} `json:"health"`
+		Sync struct {
+			Status string `json:"status"`
+		} `json:"sync"`
+		ReconciledAt string `json:"reconciledAt"`
+	} `json:"status"`
+}
+
+type argoList struct {
+	Items []argoItem `json:"items"`
+}
+
+// ── public API ────────────────────────────────────────────────────────────────
+
+// Enrich auto-detects technology and enriches the profile accordingly.
+// Errors from kubectl are silently degraded to status "unknown" per the issue
+// acceptance criteria — the tool must never crash on live failures.
+func Enrich(profile *graph.ClusterProfile, kubeconfig string) {
+	switch profile.Technology {
+	case "argocd":
+		EnrichArgoCD(profile, kubeconfig)
+	default:
+		EnrichFlux(profile, kubeconfig)
+	}
+}
+
+// EnrichFlux enriches a Flux cluster profile via kubectl kustomizations +
+// gitrepositories resources.
+func EnrichFlux(profile *graph.ClusterProfile, kubeconfig string) {
+	merged := make(map[string]NodeStatus)
+	for k, v := range fetchFluxResource(kubeconfig, "kustomizations.kustomize.toolkit.fluxcd.io") {
+		merged[k] = v
+	}
+	for k, v := range fetchFluxResource(kubeconfig, "gitrepositories.source.toolkit.fluxcd.io") {
+		merged[k] = v
+	}
+	applyToProfile(profile, merged)
+}
+
+// EnrichArgoCD enriches an ArgoCD cluster profile via kubectl applications.
+func EnrichArgoCD(profile *graph.ClusterProfile, kubeconfig string) {
+	statuses := fetchArgoResource(kubeconfig, "applications.argoproj.io")
+	applyToProfile(profile, statuses)
+}
+
+// ── fetcher helpers ───────────────────────────────────────────────────────────
+
+func fetchFluxResource(kubeconfig, resource string) map[string]NodeStatus {
+	out, err := runKubectl(kubeconfig, "get", resource, "--all-namespaces", "-o", "json")
+	if err != nil {
+		return nil
+	}
+	var list k8sList
+	if err := json.Unmarshal(out, &list); err != nil {
+		return nil
+	}
+	result := make(map[string]NodeStatus)
+	for _, item := range list.Items {
+		result[item.Metadata.Name] = statusFromConditions(item.Status.Conditions)
+	}
+	return result
+}
+
+func fetchArgoResource(kubeconfig, resource string) map[string]NodeStatus {
+	out, err := runKubectl(kubeconfig, "get", resource, "--all-namespaces", "-o", "json")
+	if err != nil {
+		return nil
+	}
+	var list argoList
+	if err := json.Unmarshal(out, &list); err != nil {
+		return nil
+	}
+	result := make(map[string]NodeStatus)
+	for _, item := range list.Items {
+		result[item.Metadata.Name] = statusFromArgo(item)
+	}
+	return result
+}
+
+func runKubectl(kubeconfig string, args ...string) ([]byte, error) {
+	if kubeconfig != "" {
+		args = append([]string{"--kubeconfig", kubeconfig}, args...)
+	}
+	return exec.Command("kubectl", args...).Output() //nolint:gosec
+}
+
+// ── status mapping ────────────────────────────────────────────────────────────
+
+func statusFromConditions(conditions []k8sCondition) NodeStatus {
+	for _, c := range conditions {
+		if c.Type != "Ready" {
+			continue
+		}
+		var status string
+		switch c.Status {
+		case "True":
+			status = "ready"
+		case "False":
+			msg := strings.ToLower(c.Message)
+			if strings.Contains(msg, "progress") || strings.Contains(msg, "reconcil") {
+				status = "progressing"
+			} else {
+				status = "failed"
+			}
+		default:
+			status = "progressing"
+		}
+		return NodeStatus{Status: status, Message: c.Message, UpdatedAt: c.LastTransitionTime}
+	}
+	return NodeStatus{Status: "unknown"}
+}
+
+func statusFromArgo(item argoItem) NodeStatus {
+	health := item.Status.Health.Status
+	sync := item.Status.Sync.Status
+	msg := item.Status.Health.Message
+	ts := item.Status.ReconciledAt
+
+	var status string
+	switch {
+	case health == "Healthy" && sync == "Synced":
+		status = "ready"
+	case health == "Degraded":
+		status = "failed"
+	case health == "Progressing" || sync == "OutOfSync":
+		status = "progressing"
+	default:
+		status = "unknown"
+	}
+	return NodeStatus{Status: status, Message: msg, UpdatedAt: ts}
+}
+
+// ── apply to profile ──────────────────────────────────────────────────────────
+
+func applyToProfile(profile *graph.ClusterProfile, statuses map[string]NodeStatus) {
+	for i := range profile.Graph.Nodes {
+		ns, ok := statuses[profile.Graph.Nodes[i].ID]
+		if ok {
+			profile.Graph.Nodes[i].Status = ns.Status
+			profile.Graph.Nodes[i].Message = ns.Message
+			profile.Graph.Nodes[i].UpdatedAt = ns.UpdatedAt
+		} else {
+			profile.Graph.Nodes[i].Status = "unknown"
+		}
+	}
+}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -108,6 +108,9 @@ type templateData struct {
 	HasArgoProjects bool
 	HasArgoAppSets  bool
 	HasArgoApps     bool
+
+	// Live mode
+	LiveRefreshed string // non-empty when -live was used
 }
 
 // WriteHTML renders the cluster profile as a standalone HTML page to w.

--- a/internal/render/template.html
+++ b/internal/render/template.html
@@ -20,6 +20,14 @@
   .dot{width:8px;height:8px;border-radius:50%;background:#3fb950;display:inline-block;
     box-shadow:0 0 6px #3fb950;animation:pulse 2s infinite}
   @keyframes pulse{0%,100%{opacity:1}50%{opacity:.4}}
+  /* Live status indicator dots on graph nodes */
+  .status-dot{width:7px;height:7px;border-radius:50%;display:inline-block;flex-shrink:0}
+  .status-dot.ready{background:#3fb950;box-shadow:0 0 5px #3fb95099}
+  .status-dot.failed{background:#f85149;box-shadow:0 0 5px #f8514999;animation:pulse 1s infinite}
+  .status-dot.progressing{background:#f0883e;box-shadow:0 0 5px #f0883e99;animation:pulse 1.5s infinite}
+  .status-dot.unknown{background:#444c56}
+  .live-badge{background:#0d2b1a;border:1px solid #3fb95066;border-radius:20px;
+    padding:4px 12px;font-size:11px;color:#3fb950;display:flex;align-items:center;gap:5px}
   .header-right{display:flex;flex-direction:column;align-items:flex-end;gap:8px}
   .flux-badge{background:#21262d;border:1px solid #30363d;border-radius:20px;
     padding:6px 14px;font-size:12px;color:#a5d6ff;display:flex;align-items:center;gap:6px}
@@ -218,6 +226,7 @@
         <div class="flux-badge mixed">🔀 Mixed GitOps</div>
       {{end}}
       <button class="print-btn" onclick="window.print()">🖨 Print / Save as PDF</button>
+      {{if .LiveRefreshed}}<div class="live-badge">🟢 Live · {{.LiveRefreshed}}</div>{{end}}
     </div>
   </div>
 
@@ -553,7 +562,12 @@ const nodeGs = svg.append("g").selectAll("g").data(nodes).join("g")
 
 nodeGs.append("rect")
   .attr("x",-NODE_W/2).attr("y",-NODE_H/2).attr("width",NODE_W).attr("height",NODE_H).attr("rx",7)
-  .attr("fill","#21262d").attr("stroke", d => COLORS[d.type]||"#58a6ff").attr("stroke-width",1.5);
+  .attr("fill","#21262d").attr("stroke", d => {
+    if (d.status==="failed") return "#f85149";
+    if (d.status==="progressing") return "#f0883e";
+    if (d.status==="ready") return "#3fb950";
+    return COLORS[d.type]||"#58a6ff";
+  }).attr("stroke-width",d => d.status && d.status!=="unknown" ? 2 : 1.5);
 
 nodeGs.each(function(d) {
   const g = d3.select(this);
@@ -612,6 +626,14 @@ function showDetail(d) {
     ["Domain",   d.domain||"–"],
     ["DependsOn",d.dependsOn?.join(", ")||"–"],
   ];
+  // Live status rows
+  if (d.status) {
+    const statusColor = {ready:"#3fb950",failed:"#f85149",progressing:"#f0883e",unknown:"#444c56"};
+    const c = statusColor[d.status]||"#8b949e";
+    rows.push(["Status", `<span style="color:${c};font-weight:700">${d.status}</span>`]);
+    if (d.message) rows.push(["Message", d.message]);
+    if (d.updatedAt) rows.push(["Updated", d.updatedAt]);
+  }
   let html = rows.map(([k,v]) =>
     `<div class="dp-row"><span class="dp-key">${k}</span><span class="dp-val">${v}</span></div>`
   ).join("");

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -17,42 +17,70 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/stuttgart-things/clusterscope/internal/graph"
+	"github.com/stuttgart-things/clusterscope/internal/live"
 	"github.com/stuttgart-things/clusterscope/internal/render"
 	"github.com/stuttgart-things/clusterscope/internal/scan"
 	"github.com/stuttgart-things/clusterscope/pkg/argocd"
 	"github.com/stuttgart-things/clusterscope/pkg/flux"
 )
 
+// Options configures optional features of the HTTP server.
+type Options struct {
+	// Live enriches every cluster profile with real-time reconciliation status
+	// fetched via kubectl. Requires kubectl on PATH and a valid KUBECONFIG.
+	Live bool
+	// Kubeconfig is the path to the kubeconfig file. Empty means kubectl default.
+	Kubeconfig string
+	// RefreshSeconds is how often (in seconds) live status is re-fetched.
+	// Defaults to 30 when Live is true.
+	RefreshSeconds int
+}
+
 // ClusterSummary is the JSON payload returned by GET /api/clusters.
 type ClusterSummary struct {
-	Name      string `json:"name"`
-	Tech      string `json:"tech"`
-	NodeCount int    `json:"nodeCount"`
-	LastScan  string `json:"lastScan"`
+	Name         string `json:"name"`
+	Tech         string `json:"tech"`
+	NodeCount    int    `json:"nodeCount"`
+	LastScan     string `json:"lastScan"`
+	LastRefreshed string `json:"lastRefreshed,omitempty"`
 }
 
 // Server holds the HTTP mux and cluster cache.
 type Server struct {
-	root    string
-	mu      sync.RWMutex
-	cache   map[string]*graph.ClusterProfile
-	scanned map[string]time.Time
+	root        string
+	opts        Options
+	mu          sync.RWMutex
+	cache       map[string]*graph.ClusterProfile
+	scanned     map[string]time.Time
+	refreshed   map[string]time.Time
 }
 
 // Start starts the HTTP server on addr, scanning root for cluster directories.
-func Start(addr, root string) error {
+func Start(addr, root string, opts Options) error {
 	if _, err := os.Stat(root); err != nil {
 		return err
 	}
 
+	if opts.Live && opts.RefreshSeconds <= 0 {
+		opts.RefreshSeconds = 30
+	}
+
 	s := &Server{
-		root:    root,
-		cache:   make(map[string]*graph.ClusterProfile),
-		scanned: make(map[string]time.Time),
+		root:      root,
+		opts:      opts,
+		cache:     make(map[string]*graph.ClusterProfile),
+		scanned:   make(map[string]time.Time),
+		refreshed: make(map[string]time.Time),
 	}
 
 	s.scanAll()
 	go s.watch()
+
+	if opts.Live {
+		log.Printf("live mode enabled  kubeconfig=%q  refresh=%ds", opts.Kubeconfig, opts.RefreshSeconds)
+		s.enrichAll()
+		go s.liveRefreshLoop()
+	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", s.handleIndex)
@@ -64,6 +92,37 @@ func Start(addr, root string) error {
 }
 
 // ── scanning ──────────────────────────────────────────────────────────────────
+
+// ── live enrichment ────────────────────────────────────────────────────────────
+
+func (s *Server) enrichAll() {
+s.mu.RLock()
+names := make([]string, 0, len(s.cache))
+for n := range s.cache {
+names = append(names, n)
+}
+s.mu.RUnlock()
+for _, name := range names {
+s.mu.Lock()
+p := s.cache[name]
+s.mu.Unlock()
+if p != nil {
+live.Enrich(p, s.opts.Kubeconfig)
+s.mu.Lock()
+s.refreshed[name] = time.Now()
+s.mu.Unlock()
+log.Printf("live enriched %s", name)
+}
+}
+}
+
+func (s *Server) liveRefreshLoop() {
+ticker := time.NewTicker(time.Duration(s.opts.RefreshSeconds) * time.Second)
+defer ticker.Stop()
+for range ticker.C {
+s.enrichAll()
+}
+}
 
 func (s *Server) scanAll() {
 	entries, err := os.ReadDir(s.root)
@@ -100,6 +159,13 @@ func (s *Server) scanCluster(path, name string) {
 	s.scanned[name] = time.Now()
 	s.mu.Unlock()
 	log.Printf("scanned %s  tech=%s  nodes=%d", name, tech, len(profile.Graph.Nodes))
+
+	if s.opts.Live {
+		live.Enrich(profile, s.opts.Kubeconfig)
+		s.mu.Lock()
+		s.refreshed[name] = time.Now()
+		s.mu.Unlock()
+	}
 }
 
 // ── file watcher ──────────────────────────────────────────────────────────────
@@ -163,12 +229,16 @@ func (s *Server) handleAPIclusters(w http.ResponseWriter, _ *http.Request) {
 
 	summaries := make([]ClusterSummary, 0, len(s.cache))
 	for name, p := range s.cache {
-		summaries = append(summaries, ClusterSummary{
+		cs := ClusterSummary{
 			Name:      name,
 			Tech:      p.Technology,
 			NodeCount: len(p.Graph.Nodes),
 			LastScan:  s.scanned[name].Format(time.RFC3339),
-		})
+		}
+		if t, ok := s.refreshed[name]; ok {
+			cs.LastRefreshed = t.Format(time.RFC3339)
+		}
+		summaries = append(summaries, cs)
 	}
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary

Implements issue #4 — real-time reconciliation status enrichment via `kubectl`.

---

## New: `internal/live/live.go`

- `Enrich(profile, kubeconfig)` — auto-detects Flux vs ArgoCD and calls the right fetcher
- **Flux**: fetches `kustomizations.kustomize.toolkit.fluxcd.io` + `gitrepositories.source.toolkit.fluxcd.io` → maps `Ready` conditions to `ready / failed / progressing / unknown`
- **ArgoCD**: fetches `applications.argoproj.io` → maps `health.status + sync.status` to status
- `kubectl` errors degrade silently to `status: "unknown"` — no crashes per acceptance criteria
- No credentials written to HTML output; follows standard kubectl KUBECONFIG conventions

## `graph.Node` — three new live fields

```go
Status    string // "ready" | "failed" | "progressing" | "unknown"
Message   string // last condition message
UpdatedAt string // ISO-8601 timestamp
```

## `serve.go` — `Options` struct + auto-refresh loop

```go
type Options struct {
    Live           bool
    Kubeconfig     string
    RefreshSeconds int  // default 30
}
func Start(addr, root string, opts Options) error
```

- `enrichAll()` + `liveRefreshLoop()` goroutine for periodic background re-enrichment
- `scanCluster()` enriches live immediately after each YAML parse when live is enabled
- `ClusterSummary` exposes `LastRefreshed` in `/api/clusters` JSON

## `main.go` — new flags

| Flag | Default | Description |
|---|---|---|
| `-live` | false | Enable kubectl live enrichment |
| `-kubeconfig` | `""` | kubeconfig path (validated before start) |
| `-refresh` | `30` | Refresh interval in seconds |

**Security:** kubeconfig file existence is validated before starting the server. Path is passed directly to kubectl `--kubeconfig` — no shell expansion.

## `template.html` — live status in D3 graph + detail panel

- **Node border color**: 🟢 green=ready, 🔴 red=failed (pulsing), 🟠 orange=progressing, default=type color
- **Detail panel**: Status (colored), Message, UpdatedAt rows appear when `d.status` is set
- **Header badge**: `🟢 Live · <timestamp>` when `{{.LiveRefreshed}}` is set
- CSS: `.status-dot` + `.live-badge` classes

## Usage

```bash
# Serve with live mode
task ui-serve-live ROOT=./clusters KUBECONFIG=~/.kube/prod PORT=8080

# Or directly
clusterscope -serve :8080 -root ./clusters -live -kubeconfig ~/.kube/prod -refresh 60

# Static single-cluster with live
clusterscope -dir ./clusters/prod -tech flux -live -kubeconfig ~/.kube/prod -out live.html
```

## Taskfile additions

- `ui-serve-live` task — serve with `-live` flag
- `.gitignore` — excludes `.task/` remote cache

---

Closes #4