### PR TITLE
feat: MkDocs docs + GitHub Pages workflow + Backstage catalog-info

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,30 @@
+---
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
+
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -134,6 +134,18 @@ tasks:
       - echo "Dashboard generated at {{ .OUT }}/index.html"
       - 'echo "Open with: xdg-open {{ .OUT }}/index.html"'
 
+  docs-serve:
+    desc: Serve MkDocs documentation locally
+    cmds:
+      - pip install mkdocs-material --quiet
+      - mkdocs serve
+
+  docs-build:
+    desc: Build MkDocs documentation to site/
+    cmds:
+      - pip install mkdocs-material --quiet
+      - mkdocs build
+
   trigger-release:
     desc: Trigger Release workflow on GitHub Actions
     cmds:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: clusterscope
+  title: clusterscope
+  description: Technology-agnostic GitOps cluster visualizer CLI + server (Flux & ArgoCD)
+  annotations:
+    github.com/project-slug: stuttgart-things/clusterscope
+    backstage.io/techdocs-ref: dir:.
+  tags:
+    - go
+    - gitops
+    - flux
+    - argocd
+    - kubernetes
+    - visualization
+    - cli
+    - platform-engineering
+  links:
+    - url: https://stuttgart-things.github.io/clusterscope/
+      title: Documentation
+      icon: docs
+    - url: https://github.com/stuttgart-things/clusterscope/releases
+      title: Releases
+      icon: github
+spec:
+  type: tool
+  lifecycle: production
+  owner: group:default/stuttgart-things
+  system: platform-engineering

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,91 @@
+# Architecture
+
+## Overview
+
+```mermaid
+graph TD
+    A[YAML files on disk] --> B[pkg/flux.ParseDir]
+    A --> C[pkg/argocd.ParseDir]
+    B --> D[graph.ClusterProfile]
+    C --> D
+    D --> E[render.WriteHTML]
+    D --> F[render.WriteIndex]
+    E --> G[cluster.html]
+    F --> H[index.html]
+
+    I[kubectl] --> J[internal/live.Enrich]
+    J --> D
+
+    K[internal/scan.Root] --> L[multi-cluster mode]
+    K --> M[internal/serve.Server]
+    M --> N[HTTP /clusters/name]
+    M --> O[HTTP /api/clusters]
+```
+
+## Package structure
+
+```
+cmd/
+  clusterscope/
+    main.go            # CLI entrypoint, flag parsing, mode dispatch
+
+internal/
+  graph/
+    graph.go           # Shared data model: Node, Edge, Graph, ClusterProfile
+  live/
+    live.go            # kubectl enrichment (Flux + ArgoCD)
+  render/
+    render.go          # HTML generation (WriteHTML, WriteIndex)
+    template.html      # D3.js cluster profile template
+    index.html         # Multi-cluster dashboard template
+    shell.html         # HTMX serve-mode shell
+  repos/
+    repos.go           # repos.yaml schema for git-sync mode
+  scan/
+    scan.go            # Cluster directory discovery + tech detection
+  serve/
+    serve.go           # HTTP server, file watcher, cluster cache
+
+pkg/
+  flux/
+    parser.go          # Flux YAML parser (GitRepository, Kustomization, FluxInstance)
+  argocd/
+    parser.go          # ArgoCD parser (Application, ApplicationSet, AppProject)
+
+kcl/                   # KCL deployment module (Kubernetes manifests)
+dagger/                # Dagger CI module (lint, build, image, scan)
+```
+
+## Data flow
+
+### Static mode
+
+```
+-dir <cluster>  →  ParseDir()  →  graph.ClusterProfile  →  WriteHTML()  →  .html file
+-root <dir>     →  scan.Root() →  []ClusterProfile       →  WriteHTML() × N + WriteIndex()
+```
+
+### Serve mode
+
+```
+-serve :8080  →  serve.Start()
+                 ├─ scanAll()  (on startup)
+                 ├─ watch()    (fsnotify goroutine)
+                 ├─ enrichAll() (if -live, periodic goroutine)
+                 └─ HTTP handlers: /, /api/clusters, /clusters/<name>
+```
+
+### Live enrichment
+
+```
+live.Enrich(profile, kubeconfig)
+  ├─ Flux:   kubectl get kustomizations + gitrepositories  →  status from Ready conditions
+  └─ ArgoCD: kubectl get applications                       →  status from health + sync
+```
+
+## Technology detection
+
+`internal/scan.DetectTech(dir)` reads YAML files in a directory and returns:
+
+- `"argocd"` if any file contains `argoproj.io` or `kind: Application`
+- `"flux"` otherwise

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,41 @@
+# Configuration
+
+## repos.yaml (git-sync mode)
+
+When deploying clusterscope in Kubernetes with a git-sync sidecar, a `repos.yaml` file configures which Git repositories are synced to the `-root` directory.
+
+Pass the file path via `-repos-config`:
+
+```bash
+clusterscope -serve :8080 -root /data -repos-config /etc/git-sync/repos.yaml
+```
+
+### Schema
+
+```yaml
+repos:
+  - name: prod-clusters
+    url: https://github.com/my-org/gitops-clusters.git
+    branch: main
+    path: clusters/prod
+    auth:
+      secretRef: gitops-repo-secret
+
+  - name: staging-clusters
+    url: https://github.com/my-org/gitops-clusters.git
+    branch: staging
+    path: clusters/staging
+```
+
+### Fields
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | ✓ | Unique identifier for the repository |
+| `url` | ✓ | Git repository URL |
+| `branch` | ✓ | Branch to sync |
+| `path` | — | Subdirectory within the repo to use as cluster root |
+| `auth.secretRef` | — | Name of the Kubernetes Secret containing credentials |
+
+!!! note
+    The `repos-config` flag only informs clusterscope of which repos are configured. The actual git-sync is performed by the git-sync sidecar container — clusterscope only reads the synced files from disk.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,68 @@
+# Contributing
+
+## Development setup
+
+```bash
+git clone https://github.com/stuttgart-things/clusterscope.git
+cd clusterscope
+go build ./...
+go test ./...
+```
+
+Requires **Go 1.22+** and [Task](https://taskfile.dev).
+
+## Available tasks
+
+```bash
+task --list
+```
+
+Key tasks:
+
+| Task | Description |
+|---|---|
+| `task lint` | Run golangci-lint via Dagger |
+| `task build-test-binary` | Build + test via Dagger |
+| `task build-output-binary` | Build binary to `/tmp/go/build/` |
+| `task build-scan-image-ko` | Build + push + scan container image |
+| `task ui-serve ROOT=./clusters` | Run serve mode locally |
+| `task ui-serve-live ROOT=./clusters` | Run serve mode with live enrichment |
+| `task ui-static ROOT=./clusters` | Generate static HTML dashboard |
+| `task render-manifests` | Render KCL Kubernetes manifests |
+
+## Running tests locally
+
+```bash
+go test ./...
+```
+
+## Linting
+
+```bash
+task lint
+# or directly:
+dagger call -m ./dagger lint --src .
+```
+
+## Adding a new parser
+
+1. Create `pkg/<technology>/parser.go`
+2. Implement `ParseDir(dir string) (*graph.ClusterProfile, error)`
+3. Populate `graph.Node` with `Type`, `Layer`, `Sub`, `Source`, `Path`, etc.
+4. Add technology detection in `internal/scan/scan.go` → `DetectTech()`
+5. Wire up in `cmd/clusterscope/main.go` and `internal/serve/serve.go`
+
+## PR workflow
+
+1. Create a feature branch: `git checkout -b feature/my-feature`
+2. Implement + test
+3. `go build ./... && task lint`
+4. Push and open a PR targeting `main`
+5. CI runs lint + build automatically
+
+## Code style
+
+- Standard Go formatting (`gofmt`)
+- `golangci-lint` with project config
+- No panics in library code — return errors
+- Security: no credentials in HTML output, validate external inputs at boundaries

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,50 @@
+# clusterscope
+
+**Technology-agnostic GitOps cluster visualizer CLI + server.**
+
+clusterscope parses your GitOps YAML files (Flux or ArgoCD) and generates interactive HTML dashboards showing the dependency graph, sources, kustomizations, and applications of your Kubernetes clusters — with no cluster access required.
+
+## Features
+
+- **Flux & ArgoCD support** — auto-detects technology from YAML content
+- **Interactive D3.js graph** — dependency visualization with hover and click
+- **Multi-cluster dashboard** — index page linking all cluster profiles
+- **Serve mode** — live HTTP server with file watcher and auto-reload
+- **Live mode** — real-time reconciliation status via `kubectl`
+- **PDF export** — print-optimized CSS layout via browser print dialog
+- **KCL deployment** — Kubernetes manifests with git-sync sidecar
+- **Backstage integration** — `catalog-info.yaml` for discovery
+
+## Quickstart
+
+```bash
+# Single cluster (Flux)
+clusterscope -dir ./clusters/prod -out profile.html
+
+# Single cluster (ArgoCD)
+clusterscope -dir ./argocd/prod -tech argocd -out profile.html
+
+# Multi-cluster static dashboard
+clusterscope -root ./clusters -out ./dist
+
+# Live HTTP dashboard
+clusterscope -serve :8080 -root ./clusters
+
+# Live mode with kubectl enrichment
+clusterscope -serve :8080 -root ./clusters -live -kubeconfig ~/.kube/prod
+```
+
+## Supported Technologies
+
+| Technology | Parser | Resources |
+|---|---|---|
+| Flux | `pkg/flux` | GitRepository, Kustomization, FluxInstance |
+| ArgoCD | `pkg/argocd` | Application, ApplicationSet, AppProject |
+
+## Task shortcuts
+
+```bash
+task ui-serve ROOT=./clusters PORT=8080
+task ui-static ROOT=./clusters OUT=./dist
+task ui-serve-live ROOT=./clusters KUBECONFIG=~/.kube/prod
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,42 @@
+# Installation
+
+## Binary (pre-built)
+
+Download the latest release from [GitHub Releases](https://github.com/stuttgart-things/clusterscope/releases):
+
+```bash
+# Linux amd64
+curl -L https://github.com/stuttgart-things/clusterscope/releases/latest/download/clusterscope-linux-amd64 \
+  -o /usr/local/bin/clusterscope && chmod +x /usr/local/bin/clusterscope
+```
+
+## Build from source
+
+```bash
+git clone https://github.com/stuttgart-things/clusterscope.git
+cd clusterscope
+go build -o clusterscope ./cmd/clusterscope
+```
+
+Requires **Go 1.22+**.
+
+## Docker / Container
+
+```bash
+docker run --rm -v $(pwd)/clusters:/data \
+  ghcr.io/stuttgart-things/clusterscope:latest \
+  -serve :8080 -root /data
+```
+
+## Kubernetes (KCL)
+
+See [KCL Deployment](kcl.md) for deploying clusterscope as a Kubernetes workload with git-sync sidecar.
+
+## Task (via Taskfile)
+
+If you use [Task](https://taskfile.dev):
+
+```bash
+task build-output-binary
+# Binary written to /tmp/go/build/clusterscope
+```

--- a/docs/kcl.md
+++ b/docs/kcl.md
@@ -1,0 +1,66 @@
+# KCL Deployment
+
+clusterscope ships with a [KCL](https://kcl-lang.io/) deployment module that generates the Kubernetes manifests for running it as a server with an optional git-sync sidecar.
+
+## Render manifests
+
+```bash
+# Interactive (uses gum for prompts)
+task render-manifests
+
+# Non-interactive with defaults
+task render-manifests-quick
+
+# With custom profile
+task render-manifests-quick PROFILE=tests/kcl-deploy-profile.yaml
+```
+
+## Deployment profile
+
+```yaml
+# tests/kcl-deploy-profile.yaml
+config:
+  image: ghcr.io/stuttgart-things/clusterscope:latest
+  replicas: 1
+  namespace: clusterscope
+  serviceType: ClusterIP
+  rootPath: /data/clusters
+  servePort: "8080"
+
+  # git-sync sidecar
+  gitSyncEnabled: true
+  gitSyncImage: registry.k8s.io/git-sync/git-sync:v4.4.0
+  reposConfig: /etc/git-sync/repos.yaml
+
+  repoAuthSecrets:
+    - gitops-repo-secret
+
+labels:
+  app: clusterscope
+  version: latest
+```
+
+## Generated resources
+
+| Resource | Description |
+|---|---|
+| `Deployment` | clusterscope server + optional git-sync sidecar |
+| `Service` | Exposes the HTTP dashboard |
+| `ConfigMap` | repos.yaml configuration |
+
+## git-sync sidecar
+
+When `gitSyncEnabled: true`, a git-sync container is added alongside the clusterscope container:
+
+- Mounts a shared `emptyDir` volume at `/data/clusters`
+- Reads `repos.yaml` from the ConfigMap mounted at `/etc/git-sync/`
+- Periodically syncs the configured Git repositories into the shared volume
+- clusterscope reads cluster YAML files from the synced directories
+
+## Kustomize OCI push
+
+```bash
+task push-kustomize-oci
+```
+
+Pushes the rendered manifests as an OCI artifact to `ghcr.io/stuttgart-things/clusterscope-kustomize`.

--- a/docs/live.md
+++ b/docs/live.md
@@ -1,0 +1,59 @@
+# Live Mode
+
+Live mode enriches the static YAML-parsed graph with real-time reconciliation status fetched from a running cluster via `kubectl`.
+
+## Requirements
+
+- `kubectl` on `PATH`
+- A valid `KUBECONFIG` (environment variable or `-kubeconfig` flag)
+- Cluster API access (read-only on relevant CRDs)
+
+## Usage
+
+```bash
+# Serve with live enrichment
+clusterscope -serve :8080 -root ./clusters -live -kubeconfig ~/.kube/prod
+
+# Single-cluster static with live
+clusterscope -dir ./clusters/prod -tech flux -live -kubeconfig ~/.kube/prod -out live.html
+
+# Custom refresh interval (default: 30s)
+clusterscope -serve :8080 -root ./clusters -live -refresh 60
+```
+
+## Status values
+
+| Status | Color | Meaning |
+|---|---|---|
+| `ready` | 🟢 Green | Resource reconciled successfully |
+| `failed` | 🔴 Red | Reconciliation failed |
+| `progressing` | 🟠 Orange | Reconciliation in progress |
+| `unknown` | Grey | kubectl unreachable or no status available |
+
+## Data sources
+
+### Flux
+
+| Resource | API Group |
+|---|---|
+| Kustomizations | `kustomize.toolkit.fluxcd.io` |
+| GitRepositories | `source.toolkit.fluxcd.io` |
+
+### ArgoCD
+
+| Resource | API Group |
+|---|---|
+| Applications | `argoproj.io` |
+
+## UI changes in live mode
+
+- Node border color reflects live status (instead of type color)
+- Clicking a node shows `Status`, `Message`, and `UpdatedAt` in the detail panel
+- A `🟢 Live · <timestamp>` badge appears in the cluster profile header
+
+## Security
+
+- No credentials are written to HTML output
+- `KUBECONFIG` follows standard kubectl conventions
+- kubeconfig path is validated (file must exist) before the server starts
+- Errors from `kubectl` degrade silently to `status: "unknown"` — the server never crashes on live failures

--- a/docs/pdf.md
+++ b/docs/pdf.md
@@ -1,0 +1,28 @@
+# PDF Export
+
+Every cluster profile HTML page includes a **🖨 Print / Save as PDF** button in the header.
+
+## Usage
+
+1. Open a cluster profile in your browser (served or static HTML)
+2. Click **🖨 Print / Save as PDF** in the top-right header
+3. In the browser print dialog, select **Save as PDF** → A4
+
+Or use the keyboard shortcut: `Ctrl+P` / `Cmd+P`
+
+## Print layout
+
+The `@media print` CSS automatically:
+
+- **Hides** interactive elements: filter bar, graph SVG, detail panel, toggle buttons, search box
+- **Shows** print-only summary tables:
+  - Kustomizations (Name, Path, Version, Domain, DependsOn)
+  - Git Sources (Name, URL, Branch, Interval)
+  - ArgoCD Applications (Name, Project, Repo, Path, Revision, Namespace)
+- Applies a **light-on-white** color scheme (GitHub light style)
+- Sets **A4 page size** with 1.5cm margins
+- Adds **page breaks** between sections
+
+## No extra dependencies
+
+PDF export is implemented purely via browser CSS — no Chromium, no Go PDF library, no additional binaries required.

--- a/docs/serve.md
+++ b/docs/serve.md
@@ -1,0 +1,39 @@
+# Serve Mode
+
+clusterscope can run as a persistent HTTP dashboard server that watches your cluster directories for changes and serves interactive HTML profiles.
+
+## Start the server
+
+```bash
+clusterscope -serve :8080 -root ./clusters
+```
+
+Open `http://localhost:8080` in your browser.
+
+## How it works
+
+1. On startup, all subdirectories of `-root` are scanned and parsed
+2. Technology is auto-detected per cluster (Flux vs ArgoCD)
+3. A file watcher monitors `-root` for YAML changes
+4. Changes are debounced (500ms) and trigger a re-scan of the affected cluster
+5. The `/api/clusters` endpoint returns a JSON summary of all clusters
+6. `/clusters/<name>` returns the HTML profile for a specific cluster
+
+## Endpoints
+
+| Path | Description |
+|---|---|
+| `/` | HTMX shell with cluster selector |
+| `/api/clusters` | JSON list of cluster summaries |
+| `/clusters/<name>` | HTML profile for cluster `<name>` |
+
+## Taskfile
+
+```bash
+task ui-serve ROOT=./clusters PORT=8080
+task ui-serve-live ROOT=./clusters KUBECONFIG=~/.kube/prod
+```
+
+## Kubernetes deployment
+
+See [KCL Deployment](kcl.md) for running clusterscope in a cluster with a git-sync sidecar that keeps `-root` synchronized from a Git repository.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,59 @@
+# CLI Reference
+
+## Synopsis
+
+```
+clusterscope [flags]
+```
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `-dir` | `.` | Path to the cluster directory to visualize |
+| `-tech` | `flux` | Technology to parse: `flux` or `argocd` |
+| `-out` | stdout | Output file path (`.html`) |
+| `-root` | `.` | Root directory containing cluster subdirs |
+| `-serve` | — | Start HTTP dashboard server (e.g. `:8080`) |
+| `-live` | `false` | Enrich graph with real-time kubectl status |
+| `-kubeconfig` | — | Path to kubeconfig file |
+| `-refresh` | `30` | Live status refresh interval in seconds |
+| `-repos-config` | — | Path to repos.yaml (git-sync Kubernetes mode) |
+
+## Examples
+
+### Single cluster — Flux
+
+```bash
+clusterscope -dir ./clusters/prod
+clusterscope -dir ./clusters/prod -out profile.html
+```
+
+### Single cluster — ArgoCD
+
+```bash
+clusterscope -dir ./argocd/prod -tech argocd -out prod.html
+```
+
+### Multi-cluster static dashboard
+
+```bash
+clusterscope -root ./clusters -out ./dist
+# Generates: dist/index.html + dist/<cluster-name>.html per cluster
+```
+
+### Serve mode
+
+```bash
+clusterscope -serve :8080 -root ./clusters
+```
+
+See [Serve Mode](serve.md) for details.
+
+### Live mode
+
+```bash
+clusterscope -serve :8080 -root ./clusters -live -kubeconfig ~/.kube/prod
+```
+
+See [Live Mode](live.md) for details.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,52 @@
+---
+site_name: clusterscope
+site_description: Technology-agnostic GitOps cluster visualizer CLI + server
+site_url: https://stuttgart-things.github.io/clusterscope/
+repo_url: https://github.com/stuttgart-things/clusterscope
+repo_name: stuttgart-things/clusterscope
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    scheme: slate
+    primary: blue
+    accent: cyan
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - content.code.annotate
+    - search.highlight
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - attr_list
+
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - Usage:
+      - CLI Reference: usage.md
+      - Serve Mode: serve.md
+      - Live Mode: live.md
+      - PDF Export: pdf.md
+  - Configuration:
+      - repos.yaml: configuration.md
+      - KCL Deployment: kcl.md
+  - Architecture: architecture.md
+  - Contributing: contributing.md


### PR DESCRIPTION
## Summary

Implements issues #18, #19, #20 in a single PR.

---

## Issue #18 — MkDocs documentation site

**New:** `mkdocs.yml` — Material theme (slate + blue/cyan), navigation tabs, Mermaid support

**New:** `docs/` directory with 10 pages:

| File | Content |
|---|---|
| `index.md` | Overview, feature list, quickstart |
| `installation.md` | Binary, source build, Docker, Task |
| `usage.md` | Full CLI flag reference with examples |
| `serve.md` | Serve mode, HTTP endpoints, file watcher |
| `live.md` | Live mode, status values, kubectl data sources, security |
| `pdf.md` | PDF export via print CSS |
| `configuration.md` | repos.yaml schema + field reference |
| `kcl.md` | KCL Kubernetes deployment, git-sync sidecar |
| `architecture.md` | Mermaid data flow + package structure diagram |
| `contributing.md` | Dev setup, task reference, adding parsers, PR workflow |

**Modified:** `Taskfile.yaml` — added `docs-serve` and `docs-build` tasks

```bash
task docs-serve   # mkdocs serve (local preview)
task docs-build   # mkdocs build → site/
```

---

## Issue #19 — GitHub Pages via mkdocs gh-deploy

**New:** `.github/workflows/docs.yaml`

- Triggers on push to `main` when `docs/**` or `mkdocs.yml` changes + `workflow_dispatch`
- Installs `mkdocs-material`
- Runs `mkdocs gh-deploy --force` → publishes to `gh-pages` branch

**URL after merge:** `https://stuttgart-things.github.io/clusterscope/`

---

## Issue #20 — Backstage catalog-info.yaml

**New:** `catalog-info.yaml`

```yaml
kind: Component
spec:
  type: tool
  lifecycle: production
  owner: group:default/stuttgart-things
  system: platform-engineering
```

- Tags: `go`, `gitops`, `flux`, `argocd`, `kubernetes`, `visualization`, `cli`, `platform-engineering`
- `backstage.io/techdocs-ref: dir:.` — TechDocs from mkdocs
- Links to documentation + GitHub releases

---

Closes #18
Closes #19
Closes #20