### PR TITLE
feat(kcl): support authentication for private git repositories in git-sync sidecar

### DIFF
--- a/kcl/deploy.k
+++ b/kcl/deploy.k
@@ -6,6 +6,50 @@ import labels
 
 config = labels.config
 
+# Conditional SSH arg for git-sync
+_sshArgs = ["--ssh-key-file=/etc/git-sync-secrets/{}/ssh".format(config.gitSyncAuthSecretName)] if config.gitSyncAuthSecretName != "" and config.gitSyncAuthType == "ssh" else []
+
+# Conditional HTTPS auth env vars for git-sync
+_authEnv = [
+    {
+        name: "GITSYNC_USERNAME"
+        valueFrom: {
+            secretKeyRef: {
+                name: config.gitSyncAuthSecretName
+                key: "username"
+            }
+        }
+    }
+    {
+        name: "GITSYNC_PASSWORD"
+        valueFrom: {
+            secretKeyRef: {
+                name: config.gitSyncAuthSecretName
+                key: "password"
+            }
+        }
+    }
+] if config.gitSyncAuthSecretName != "" and config.gitSyncAuthType == "https" else []
+
+# Conditional auth volume mount
+_authVolumeMount = [
+    {
+        name: "secret-auth"
+        mountPath: "/etc/git-sync-secrets/{}".format(config.gitSyncAuthSecretName)
+        readOnly: True
+    }
+] if config.gitSyncAuthSecretName != "" else []
+
+# Conditional auth volume
+_authVolume = [
+    {
+        name: "secret-auth"
+        secret: {
+            secretName: config.gitSyncAuthSecretName
+        }
+    }
+] if config.gitSyncAuthSecretName != "" else []
+
 # git-sync sidecar container (only added when gitSyncEnabled=true)
 _gitSyncContainer = {
     name: "git-sync"
@@ -16,13 +60,13 @@ _gitSyncContainer = {
         "--root=/data"
         "--period={}".format(config.gitSyncPeriod)
         "--depth=1"
-    ]
+    ] + _sshArgs
     env: [
         {
             name: "GITSYNC_ONE_TIME"
             value: "false"
         }
-    ]
+    ] + _authEnv
     securityContext: {
         readOnlyRootFilesystem: True
         runAsNonRoot: True
@@ -58,7 +102,7 @@ _gitSyncContainer = {
             readOnly: True
         }
         for s in config.repoAuthSecrets
-    ]
+    ] + _authVolumeMount
 }
 
 # extra volumes for git-sync (tmp + auth Secrets)
@@ -75,7 +119,7 @@ _gitSyncVolumes = [
         }
     }
     for s in config.repoAuthSecrets
-]
+] + _authVolume
 
 deployment = {
     apiVersion: "apps/v1"

--- a/kcl/schema.k
+++ b/kcl/schema.k
@@ -44,6 +44,14 @@ schema ClusterScope:
     # Each secret is mounted at /etc/git-sync-secrets/<secret-name>/
     repoAuthSecrets: [str] = []
 
+    # Authentication for private git repositories
+    # Name of the Kubernetes Secret containing auth credentials
+    # For HTTPS: secret must have keys 'username' and 'password'
+    # For SSH:   secret must have key 'ssh' (private key)
+    gitSyncAuthSecretName: str = ""
+    # Auth type: 'https' (token/password) or 'ssh'
+    gitSyncAuthType: str = "https"
+
     # HTTPRoute (Gateway API)
     httpRouteEnabled: bool = False
     gatewayName: str = ""
@@ -60,3 +68,4 @@ schema ClusterScope:
         name != "", "name must not be empty"
         namespace != "", "namespace must not be empty"
         tech in ["flux", "argocd"], "tech must be one of: flux, argocd"
+        gitSyncAuthType in ["https", "ssh"], "gitSyncAuthType must be 'https' or 'ssh'"

--- a/tests/kcl-deploy-profile.yaml
+++ b/tests/kcl-deploy-profile.yaml
@@ -19,6 +19,11 @@ kcl_options:
     value: main
   - key: config.gitSyncPeriod
     value: 60s
+  # Auth for private repos (optional):
+  # - key: config.gitSyncAuthSecretName
+  #   value: git-sync-auth          # K8s secret with keys: username + password (HTTPS) or ssh (SSH)
+  # - key: config.gitSyncAuthType
+  #   value: https                  # 'https' or 'ssh'
   - key: config.httpRouteEnabled
     value: "true"
   - key: config.gatewayName


### PR DESCRIPTION
## Summary

Implements authentication support for private git repositories in the git-sync sidecar container.

Closes #24

## Changes

### `kcl/schema.k`
- Added `gitSyncAuthSecretName: str = ""` — name of a Kubernetes Secret holding auth credentials
- Added `gitSyncAuthType: str = "https"` — auth method: `https` or `ssh`
- Added validation: `gitSyncAuthType in ["https", "ssh"]`

### `kcl/deploy.k`
- **HTTPS auth**: When `gitSyncAuthSecretName` is set and `gitSyncAuthType == "https"`, injects `GITSYNC_USERNAME` and `GITSYNC_PASSWORD` env vars sourced from the secret's `username`/`password` keys
- **SSH auth**: When `gitSyncAuthType == "ssh"`, appends `--ssh-key-file=/etc/git-sync-secrets/<secret>/ssh` to git-sync args
- Auth secret is auto-mounted as a volume at `/etc/git-sync-secrets/<secret-name>/`
- Uses helper variables (`_sshArgs`, `_authEnv`, `_authVolumeMount`, `_authVolume`) for clean conditional logic

### `tests/kcl-deploy-profile.yaml`
- Added commented-out example for auth configuration

## Usage

**HTTPS token (GitHub PAT):**
```bash
kubectl create secret generic git-sync-auth \
  --from-literal=username=token \
  --from-literal=password=<GITHUB_TOKEN> \
  -n clusterscope
```
```yaml
- key: config.gitSyncAuthSecretName
  value: git-sync-auth
- key: config.gitSyncAuthType
  value: https
```

**SSH key:**
```bash
kubectl create secret generic git-sync-ssh \
  --from-file=ssh=/home/user/.ssh/id_rsa \
  -n clusterscope
```
```yaml
- key: config.gitSyncAuthSecretName
  value: git-sync-ssh
- key: config.gitSyncAuthType
  value: ssh
```

## Backward Compatibility

- `gitSyncAuthSecretName` defaults to `""` → no auth injected → existing public repo behavior unchanged
