### PR TITLE
feat(kcl): support multiple git repositories and cluster folders simultaneously

### DIFF
--- a/kcl/deploy.k
+++ b/kcl/deploy.k
@@ -6,10 +6,12 @@ import labels
 
 config = labels.config
 
-# Conditional SSH arg for git-sync
+# ── Single-repo helpers ──────────────────────────────────────────────────────
+
+# Conditional SSH arg for single-repo git-sync
 _sshArgs = ["--ssh-key-file=/etc/git-sync-secrets/{}/ssh".format(config.gitSyncAuthSecretName)] if config.gitSyncAuthSecretName != "" and config.gitSyncAuthType == "ssh" else []
 
-# Conditional HTTPS auth env vars for git-sync
+# Conditional HTTPS auth env vars for single-repo git-sync
 _authEnv = [
     {
         name: "GITSYNC_USERNAME"
@@ -31,7 +33,7 @@ _authEnv = [
     }
 ] if config.gitSyncAuthSecretName != "" and config.gitSyncAuthType == "https" else []
 
-# Conditional auth volume mount
+# Conditional auth volume mount (single-repo)
 _authVolumeMount = [
     {
         name: "secret-auth"
@@ -40,7 +42,7 @@ _authVolumeMount = [
     }
 ] if config.gitSyncAuthSecretName != "" else []
 
-# Conditional auth volume
+# Conditional auth volume (single-repo)
 _authVolume = [
     {
         name: "secret-auth"
@@ -50,7 +52,7 @@ _authVolume = [
     }
 ] if config.gitSyncAuthSecretName != "" else []
 
-# git-sync sidecar container (only added when gitSyncEnabled=true)
+# Single git-sync sidecar container (used when gitSyncEnabled=true and gitSyncRepos is empty)
 _gitSyncContainer = {
     name: "git-sync"
     image: config.gitSyncImage
@@ -105,7 +107,7 @@ _gitSyncContainer = {
     ] + _authVolumeMount
 }
 
-# extra volumes for git-sync (tmp + auth Secrets)
+# extra volumes for single git-sync (tmp + auth Secrets)
 _gitSyncVolumes = [
     {
         name: "git-sync-tmp"
@@ -120,6 +122,107 @@ _gitSyncVolumes = [
     }
     for s in config.repoAuthSecrets
 ] + _authVolume
+
+# ── Multi-repo helpers ───────────────────────────────────────────────────────
+
+# Build one git-sync container per entry in gitSyncRepos
+_multiGitSyncContainers = [
+    {
+        name: "git-sync-{}".format(r.subdir)
+        image: config.gitSyncImage
+        args: [
+            "--repo={}".format(r.repo)
+            "--ref={}".format(r.branch)
+            "--root=/data/{}".format(r.subdir)
+            "--period={}".format(r.period)
+            "--depth=1"
+        ] + (["--ssh-key-file=/etc/git-sync-secrets/{}/ssh".format(r.authSecretName)] if r.authSecretName != "" and r.authType == "ssh" else [])
+        env: [
+            {
+                name: "GITSYNC_ONE_TIME"
+                value: "false"
+            }
+        ] + ([
+            {
+                name: "GITSYNC_USERNAME"
+                valueFrom: {
+                    secretKeyRef: {
+                        name: r.authSecretName
+                        key: "username"
+                    }
+                }
+            }
+            {
+                name: "GITSYNC_PASSWORD"
+                valueFrom: {
+                    secretKeyRef: {
+                        name: r.authSecretName
+                        key: "password"
+                    }
+                }
+            }
+        ] if r.authSecretName != "" and r.authType == "https" else [])
+        securityContext: {
+            readOnlyRootFilesystem: True
+            runAsNonRoot: True
+            runAsUser: 65533
+            allowPrivilegeEscalation: False
+            capabilities: {
+                drop: ["ALL"]
+            }
+        }
+        resources: {
+            requests: {
+                cpu: "10m"
+                memory: "32Mi"
+            }
+            limits: {
+                cpu: "100m"
+                memory: "128Mi"
+            }
+        }
+        volumeMounts: [
+            {
+                name: "gitdata"
+                mountPath: "/data"
+            }
+            {
+                name: "git-sync-tmp-{}".format(r.subdir)
+                mountPath: "/tmp"
+            }
+        ] + ([
+            {
+                name: "secret-repo-{}".format(r.subdir)
+                mountPath: "/etc/git-sync-secrets/{}".format(r.authSecretName)
+                readOnly: True
+            }
+        ] if r.authSecretName != "" else [])
+    }
+    for r in config.gitSyncRepos
+]
+
+# Build volumes for each entry in gitSyncRepos
+_multiGitSyncVolumes = [
+    {
+        name: "git-sync-tmp-{}".format(r.subdir)
+        emptyDir: {}
+    }
+    for r in config.gitSyncRepos
+] + [
+    {
+        name: "secret-repo-{}".format(r.subdir)
+        secret: {
+            secretName: r.authSecretName
+        }
+    }
+    for r in config.gitSyncRepos if r.authSecretName != ""
+]
+
+# Choose between single-repo and multi-repo mode
+_isMultiRepo = len(config.gitSyncRepos) > 0
+_activeSyncContainers = _multiGitSyncContainers if _isMultiRepo else ([_gitSyncContainer] if config.gitSyncEnabled else [])
+_activeSyncVolumes = _multiGitSyncVolumes if _isMultiRepo else (_gitSyncVolumes if config.gitSyncEnabled else [])
+
 
 deployment = {
     apiVersion: "apps/v1"
@@ -209,7 +312,7 @@ deployment = {
                             }
                         ]
                     }
-                ] + ([_gitSyncContainer] if config.gitSyncEnabled else [])
+                ] + _activeSyncContainers
                 affinity: {
                     podAntiAffinity: {
                         preferredDuringSchedulingIgnoredDuringExecution: [
@@ -243,7 +346,7 @@ deployment = {
                         name: "gitdata"
                         emptyDir: {}
                     }
-                ] + (_gitSyncVolumes if config.gitSyncEnabled else [])
+                ] + _activeSyncVolumes
             }
         }
     }

--- a/kcl/labels.k
+++ b/kcl/labels.k
@@ -16,6 +16,9 @@ _gitSyncImage = option("config.gitSyncImage")
 _gitSyncRepo = option("config.gitSyncRepo")
 _gitSyncBranch = option("config.gitSyncBranch")
 _gitSyncPeriod = option("config.gitSyncPeriod")
+_gitSyncAuthSecretName = option("config.gitSyncAuthSecretName")
+_gitSyncAuthType = option("config.gitSyncAuthType")
+_gitSyncRepos = option("config.gitSyncRepos")
 _httpRouteEnabled = option("config.httpRouteEnabled")
 _gatewayName = option("config.gatewayName")
 _gatewayNamespace = option("config.gatewayNamespace")
@@ -46,6 +49,12 @@ config: schema.ClusterScope = schema.ClusterScope {
         gitSyncBranch = _gitSyncBranch
     if _gitSyncPeriod:
         gitSyncPeriod = _gitSyncPeriod
+    if _gitSyncAuthSecretName:
+        gitSyncAuthSecretName = _gitSyncAuthSecretName
+    if _gitSyncAuthType:
+        gitSyncAuthType = _gitSyncAuthType
+    if _gitSyncRepos:
+        gitSyncRepos = _gitSyncRepos
     if _httpRouteEnabled:
         httpRouteEnabled = _httpRouteEnabled == True or str(_httpRouteEnabled) in ["true", "True", "1"]
     if _gatewayName:

--- a/kcl/schema.k
+++ b/kcl/schema.k
@@ -2,6 +2,28 @@
 Schema definition for clusterscope deployment configuration
 """
 
+schema GitSyncRepo:
+    """Configuration for a single git-sync sidecar watching one repository"""
+    # Git repository URL to sync
+    repo: str
+    # Branch to sync
+    branch: str = "main"
+    # Subdirectory under /data/ where the repo is synced (e.g. "harvester", "st-clusters")
+    subdir: str
+    # Sync interval (e.g. 60s, 5m)
+    period: str = "60s"
+    # Name of the Kubernetes Secret containing auth credentials (optional)
+    # For HTTPS: secret must have keys 'username' and 'password'
+    # For SSH:   secret must have key 'ssh' (private key)
+    authSecretName: str = ""
+    # Auth type: 'https' (token/password) or 'ssh'
+    authType: str = "https"
+
+    check:
+        repo != "", "repo must not be empty"
+        subdir != "", "subdir must not be empty"
+        authType in ["https", "ssh"], "authType must be 'https' or 'ssh'"
+
 schema ClusterScope:
     """Configuration for clusterscope Kubernetes deployment"""
 
@@ -33,6 +55,7 @@ schema ClusterScope:
     gitSyncEnabled: bool = False
     gitSyncImage: str = "registry.k8s.io/git-sync/git-sync:v4.4.0"
 
+    # Single repo (legacy / simple mode) - mutually exclusive with gitSyncRepos
     # Git repository URL to sync
     gitSyncRepo: str = ""
     # Branch to sync
@@ -40,11 +63,16 @@ schema ClusterScope:
     # Sync interval (e.g. 60s, 5m)
     gitSyncPeriod: str = "60s"
 
+    # Multi-repo mode: list of repositories to sync simultaneously.
+    # Each entry creates a dedicated git-sync sidecar syncing into /data/<subdir>/
+    # When set, gitSyncRepo/gitSyncBranch/gitSyncPeriod are ignored.
+    gitSyncRepos: [GitSyncRepo] = []
+
     # Names of Kubernetes Secrets containing auth credentials for git-sync.
     # Each secret is mounted at /etc/git-sync-secrets/<secret-name>/
     repoAuthSecrets: [str] = []
 
-    # Authentication for private git repositories
+    # Authentication for private git repositories (single-repo mode)
     # Name of the Kubernetes Secret containing auth credentials
     # For HTTPS: secret must have keys 'username' and 'password'
     # For SSH:   secret must have key 'ssh' (private key)

--- a/tests/kcl-multi-repo-profile.yaml
+++ b/tests/kcl-multi-repo-profile.yaml
@@ -1,0 +1,27 @@
+kcl_options:
+  - key: config.image
+    value: ghcr.io/stuttgart-things/clusterscope:latest
+  - key: config.namespace
+    value: clusterscope
+  - key: config.tech
+    value: flux
+  - key: config.dir
+    value: /data
+  - key: config.port
+    value: "8080"
+  - key: config.replicas
+    value: "1"
+  - key: config.gitSyncEnabled
+    value: "true"
+  - key: config.gitSyncRepos
+    value:
+      - repo: https://github.com/stuttgart-things/harvester
+        branch: main
+        subdir: harvester
+        period: 60s
+      - repo: https://github.com/stuttgart-things/clusters
+        branch: main
+        subdir: st-clusters
+        period: 120s
+  - key: config.httpRouteEnabled
+    value: "false"


### PR DESCRIPTION
## Summary

Implements support for monitoring multiple git repositories and cluster folders simultaneously via multiple git-sync sidecars.

Closes #25

## Changes

### `kcl/schema.k`
- Added new `GitSyncRepo` schema:
  - `repo: str` — Git repository URL
  - `branch: str = "main"` — Branch
  - `subdir: str` — Mount subdirectory under `/data/`
  - `period: str = "60s"` — Sync interval
  - `authSecretName: str = ""` — Optional K8s secret for auth
  - `authType: str = "https"` — Auth method: `https` or `ssh`
- Added `gitSyncRepos: [GitSyncRepo] = []` to `ClusterScope` schema

### `kcl/deploy.k`
- Generates one dedicated `git-sync-<subdir>` container per entry in `gitSyncRepos`
- Each sidecar syncs into `/data/<subdir>/` → isolated subdirectory
- Per-repo HTTPS auth (GITSYNC_USERNAME/PASSWORD) and SSH auth (--ssh-key-file) supported
- Mode selection: `gitSyncRepos` list takes priority over single-repo `gitSyncRepo`
- `_activeSyncContainers` and `_activeSyncVolumes` encapsulate the mode logic

### `kcl/labels.k`
- Added `option("config.gitSyncRepos")` + `option("config.gitSyncAuthSecretName")` + `option("config.gitSyncAuthType")`
- Wires all new options into the `ClusterScope` config instance

### `tests/kcl-multi-repo-profile.yaml`
- New example profile with 2 repos: `harvester` → `/data/harvester/` and `clusters` → `/data/st-clusters/`

## How It Works

```
/data/
  harvester/clusters/         ← git-sync-harvester (--root=/data/harvester)
  st-clusters/clusters/       ← git-sync-st-clusters (--root=/data/st-clusters)
```

clusterscope runs with `-root=/data` and scans all subdirectories.

## Usage

```yaml
- key: config.gitSyncRepos
  value:
    - repo: https://github.com/org/repo1
      branch: main
      subdir: repo1
      period: 60s
    - repo: https://github.com/org/repo2
      branch: main
      subdir: repo2
      period: 120s
      authSecretName: git-auth-secret
      authType: https
```

## Backward Compatibility

- `gitSyncRepos: []` (default) → falls back to single-repo mode (`gitSyncRepo`/`gitSyncBranch`/`gitSyncPeriod`)
- All existing profiles continue to work unchanged
