### PR TITLE
feat(kcl): cluster-specific multi-repo OCI artifact via dedicated KCL profile (#29)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,3 +21,17 @@ jobs:
       kcl-profile-file: tests/kcl-deploy-profile.yaml
       kustomize-oci-repo: ghcr.io/stuttgart-things/clusterscope-kustomize
     secrets: inherit # pragma: allowlist secret
+
+  release-multi-repo:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-go-release.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      stage-image: false
+      push-kustomize: true
+      kcl-source-dir: kcl
+      kcl-profile-file: tests/kcl-multi-repo-prod-profile.yaml
+      kustomize-oci-repo: ghcr.io/stuttgart-things/clusterscope-kustomize-multi-repo
+    secrets: inherit # pragma: allowlist secret

--- a/tests/kcl-multi-repo-prod-profile.yaml
+++ b/tests/kcl-multi-repo-prod-profile.yaml
@@ -1,0 +1,35 @@
+kcl_options:
+  - key: config.image
+    value: ghcr.io/stuttgart-things/clusterscope:latest
+  - key: config.namespace
+    value: clusterscope
+  - key: config.tech
+    value: flux
+  - key: config.dir
+    value: /data
+  - key: config.port
+    value: "8080"
+  - key: config.replicas
+    value: "1"
+  - key: config.gitSyncEnabled
+    value: "true"
+  - key: config.gitSyncRepos
+    value:
+      - repo: https://github.com/stuttgart-things/harvester
+        branch: main
+        subdir: harvester
+        period: 60s
+      - repo: https://github.com/stuttgart-things/clusters
+        branch: main
+        subdir: st-clusters
+        period: 120s
+  - key: config.httpRouteEnabled
+    value: "true"
+  - key: config.gatewayName
+    value: movie-scripts2-gateway
+  - key: config.gatewayNamespace
+    value: default
+  - key: config.hostname
+    value: clusterscope
+  - key: config.domain
+    value: movie-scripts2.sthings-vsphere.labul.sva.de


### PR DESCRIPTION
Closes #29

## Changes

### `tests/kcl-multi-repo-prod-profile.yaml` (new)
Full production profile with `gitSyncRepos` list → KCL bakes the correct `git-sync-<subdir>` sidecars into the OCI artifact:
```
clusterscope pod
├── container: clusterscope           (-root=/data -tech=flux -serve=:8080)
├── container: git-sync-harvester     (--root=/data/harvester)
└── container: git-sync-st-clusters   (--root=/data/st-clusters)
```

### `.github/workflows/release.yaml`
Added `release-multi-repo` job that runs alongside the existing `release` job:
- Uses `tests/kcl-multi-repo-prod-profile.yaml`
- Pushes to `ghcr.io/stuttgart-things/clusterscope-kustomize-multi-repo`

### `apps/flux` (separate commit)
Added `clusterscope-kustomize-multi-repo` OCIRepository + `clusterscope-deploy-multi-repo` Kustomization — both initially suspended. No patching needed: sidecars are baked in by KCL.

## Activation

To switch a cluster to multi-repo mode:
1. Remove `suspend: true` from both resources in `release.yaml`
2. The existing single-repo `clusterscope-deploy` can be suspended in parallel